### PR TITLE
Добавление необходимого импорта

### DIFF
--- a/script.py
+++ b/script.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import re
 from pathlib import Path
+import sys
 try:
     from distutils.dir_util import copy_tree
 except ModuleNotFoundError:  # в 3.12 отсутсвует "distutils"


### PR DESCRIPTION
Модуль `sys` необходим для работы кода ниже, который вызывается, если в системе не установлен setuptools (строка 10, `sys.executable`). 

<offtopic>
Спасибо за скрипт, с новыми шрифтами DRG выглядит гораздо лучше! :) 
Я бы предложил залить его в качестве мода на mod.io, но я ничего не знаю о моддинге DRG.
</offtopic>